### PR TITLE
fix: comments at Contract for (a)sync rendering / addendum to e4dcb63

### DIFF
--- a/src/Contracts/index.ts
+++ b/src/Contracts/index.ts
@@ -225,13 +225,13 @@ export interface EdgeRendererContract {
   share(locals: any): this
 
   /**
-   * Render a template synchronously
+   * Render a template asynchronously
    */
   render(templatePath: string, state?: any): Promise<string>
   renderRaw(contents: string, state?: any, templatePath?: string): Promise<string>
 
   /**
-   * Render a template asynchronously
+   * Render a template synchronously
    */
   renderSync(templatePath: string, state?: any): string
   renderRawSync(contents: string, state?: any, templatePath?: string): string
@@ -375,13 +375,13 @@ export interface EdgeContract {
   share(locals: any): EdgeRendererContract
 
   /**
-   * Render a template synchronously
+   * Render a template asynchronously
    */
   render(templatePath: string, state?: any): Promise<string>
   renderRaw(contents: string, state?: any, templatePath?: string): Promise<string>
 
   /**
-   * Render a template asynchronously
+   * Render a template synchronously
    */
   renderSync(templatePath: string, state?: any): string
   renderRawSync(contents: string, state?: any, templatePath?: string): string


### PR DESCRIPTION
## Proposed changes

Currently if you type `render` on `view` object at Adonisjs app, you will see misleading comments:
![image](https://user-images.githubusercontent.com/5501615/117190101-a9a2c700-ade7-11eb-81ee-79176d038d1a.png)

This PR fixes comments in Contract.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Further comments