### PR TITLE
feat: add template engine callback for Express framework

### DIFF
--- a/src/edge/main.ts
+++ b/src/edge/main.ts
@@ -378,4 +378,29 @@ export class Edge {
   share(data: Record<string, any>): EdgeRenderer {
     return this.createRenderer().share(data)
   }
+
+  /**
+   * Provide template engine callback for Express framework.
+   *
+   * ```js
+   * const app = express()
+   * const edge = new Edge()
+   *
+   * // register edge engine
+   * app.engine('edge', edge.express())
+   * app.set('views', './views')
+   * app.set('view engine', 'edge')
+   * ```
+   */
+  express() {
+    const self = this
+
+    return function (
+      filePath: string,
+      options: object,
+      callback: (err: Error | null, rendered: string) => void
+    ) {
+      self.render(filePath, options).then((html) => callback(null, html))
+    }
+  }
 }


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/edge-js/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Currently, using edge template with Express framework requires developers to create template engine callback manually. So, the intention of this PR is to improve integration of edge template with Express framework by providing template engine callback. I took inspiration from LiquidJS documentation in [here](https://liquidjs.com/tutorials/use-in-expressjs.html).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
