### PR TITLE
feat: expose edge renderer locals

### DIFF
--- a/src/edge/renderer.ts
+++ b/src/edge/renderer.ts
@@ -50,6 +50,13 @@ export class EdgeRenderer {
   }
 
   /**
+  * Get the shared locals
+  */
+  getLocals() {
+    return this.#locals
+  }
+
+  /**
    * Render the template
    */
   async render(templatePath: string, state: Record<string, any> = {}): Promise<string> {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/edge-js/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

i'm creating multiple renderer on the same request, and i want to access existing renderer shared data

```ts
const createRenderer = (sharedData) => {
 const renderer = edge.createRenderer()
 
 const view = HttpContext.get().view // AdonisJS Edge Renderer
 renderer.share(view.getLocals()) 
 
 renderer.share(sharedData)
 
 return renderer
}

// isolated instances
const view1 = createRenderer({ a: 1 })
const view2 = createRenderer({ b: 2 })


await view1.render("component1", {
   foo: "bar"
})

await view2.render("componen2t", {
   baz: "qux"
})
 ```


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
