### PR TITLE
feat: add support for HtmlableContract

### DIFF
--- a/src/component/props.ts
+++ b/src/component/props.ts
@@ -10,12 +10,13 @@
 import lodash from '@poppinss/utils/lodash'
 import { htmlSafe } from '../template.js'
 import { stringifyAttributes } from '../utils.js'
+import { HtmlableContract } from '../types.js'
 
 /**
  * Representation of component props with ability to serialize
  * them into HTML attributes
  */
-export class ComponentProps {
+export class ComponentProps implements HtmlableContract {
   #values: Record<string, any>
 
   constructor(values: Record<string, any>) {
@@ -115,5 +116,12 @@ export class ComponentProps {
    */
   toAttrs() {
     return htmlSafe(stringifyAttributes(this.#values))
+  }
+
+  /**
+   * Converts props to HTML attributes
+   */
+  toHtml() {
+    return stringifyAttributes(this.#values)
   }
 }

--- a/src/template.ts
+++ b/src/template.ts
@@ -32,7 +32,11 @@ class SafeValue {
  * Escapes a given string
  */
 export function escape(input: any): string {
-  return input instanceof SafeValue ? input.value : he.escape(String(input))
+  return input instanceof SafeValue
+    ? input.value
+    : input && typeof input === 'object' && 'toHtml' in input
+      ? input.toHtml()
+      : he.escape(String(input))
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,15 @@ export type ComponentsTree = {
   }[]
 }[]
 
+export interface HtmlableContract {
+  /**
+   * Get content as a string of HTML.
+   *
+   * @return string
+   */
+  toHtml(): string
+}
+
 /**
  * Loader contract that every loader must adheres to.
  */

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -191,4 +191,13 @@ test.group('ComponentProps', () => {
       'class="foo input-error input-disabled input-medium input-rounded"'
     )
   })
+
+  test('convert to HTML string', ({ assert }) => {
+    const props = ComponentProps.create({
+      title: 'Hello',
+      class: ['foo', 'bar'],
+    })
+
+    assert.equal(props.toHtml(), 'title="Hello" class="foo bar"')
+  })
 })

--- a/tests/template.spec.ts
+++ b/tests/template.spec.ts
@@ -20,6 +20,7 @@ import { Processor } from '../src/processor.js'
 import { includeTag } from '../src/tags/include.js'
 import { componentTag } from '../src/tags/component.js'
 import { Template, htmlSafe } from '../src/template.js'
+import { edgeGlobals } from '../src/edge/globals.js'
 
 const tags = { slot: slotTag, component: componentTag, include: includeTag }
 const fs = new Filesystem(join(path.dirname(fileURLToPath(import.meta.url)), 'views'))
@@ -247,5 +248,37 @@ test.group('Template', (group) => {
 
     const partailWithInlineVariables = template.compilePartial('foo', 'username')
     assert.equal(partailWithInlineVariables(template, {}, {}, 'virk').trim(), 'Hello virk')
+  })
+
+  test('do not escape object with toHtml method', ({ assert }) => {
+    const processor = new Processor()
+    const compiler = new Compiler(loader, tags, processor, { cache: false })
+    const template = new Template(compiler, {}, {}, processor)
+    assert.equal(
+      template.escape({
+        toHtml() {
+          return '<h2> Hello world </h2>'
+        },
+      }),
+      '<h2> Hello world </h2>'
+    )
+  })
+
+  test('render raw template with various data types', ({ assert }) => {
+    const processor = new Processor()
+    const compiler = new Compiler(loader, tags, processor, { cache: false })
+    const template = new Template(compiler, edgeGlobals, {}, processor)
+    assert.equal(template.renderRaw('{{ null }}', {}), 'null')
+    assert.equal(template.renderRaw('{{ undefined }}', {}), 'undefined')
+    assert.equal(template.renderRaw('{{ [1, 2, 3] }}', {}), '1,2,3')
+    assert.equal(template.renderRaw('{{ ({ hello: "world" }) }}', {}), '[object Object]')
+    assert.include(
+      template.renderRaw('{{ new Date("2025-04-22T17:00:56.000Z") }}', {}),
+      'Tue Apr 22 2025'
+    )
+    assert.include(
+      template.renderRaw('{{ html.safe("<p> hello world </p>") }}', {}),
+      '<p> hello world </p>'
+    )
   })
 })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/edge-js/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Add `HtmlableContract` interface, allowing objects with a `toHtml()` method to render unescaped HTML directly in templates. 

Example with Props:

```edge
<!-- Before -->
<button {{ $props.merge({ type: 'text' }).toAttrs() }}>
</button>

<!-- After -->
<button {{ $props.merge({ type: 'text' }) }}>
</button>
```

Example for creating Form and rendering it

```ts
import type  { HtmlableContract }  from "edge.js/types"

class Form implements HtmlableContract {
   toHtml() {
     return "<form />"
   }
}

let form =  new Form(...)
```

```edge
{{ form }}
```

Added test case to verify correct implementation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
