### PR TITLE
feat: Add getState() method on renderer to provide a way to test sharing of variables

### DIFF
--- a/src/edge/renderer.ts
+++ b/src/edge/renderer.ts
@@ -63,6 +63,17 @@ export class EdgeRenderer {
   }
 
   /**
+   * Retrieves the local and global variables, used for testing things that
+   * share variables
+   */
+  getState(): Record<string, any> {
+    return {
+      ...this.#globals,
+      ...this.#locals,
+    }
+  }
+
+  /**
    * Render the template
    */
   async render(templatePath: string, state: Record<string, any> = {}): Promise<string> {

--- a/tests/edge.spec.ts
+++ b/tests/edge.spec.ts
@@ -443,6 +443,25 @@ test.group('Edge', () => {
     assert.equal(output1.trim(), 'Hello nikk')
     assert.equal(output2.trim(), 'Hello guest')
   })
+
+  test('retrieve shared data from renderer', async ({ assert, fs }) => {
+    const edge = new Edge()
+    await fs.create('foo.edge', "Hello {{ username || 'guest' }}")
+
+    edge.mount(fs.basePath)
+
+    const tmpl = edge.share({ username: 'jane' })
+    const tmpl1 = tmpl.clone()
+
+    tmpl1.share({ username: 'nikk' })
+
+    // getState also exposes all the globals, so we're just testing the
+    // explicitly shared value, here jane comes from the globals:
+    assert.equal(tmpl.getState().username, 'jane')
+
+    // tmpl1 overrides the username, so it comes from the locals:
+    assert.equal(tmpl1.getState().username, 'nikk')
+  })
 })
 
 test.group('Edge | regression', () => {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/edge-js/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

Fixes #165 by implementing a `getState()` method.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows for testing of code that shares data with templates, as now we can retrieve the variables as the template would see them. Note: this doesn't implement compat mode, my reasoning for not implementing that is because it's probably unlikely that you'd be testing the shared variables in code that's under compat.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
