### PR TITLE
feat: add pushToTop and pushToTopOnce

### DIFF
--- a/src/edge/stacks.ts
+++ b/src/edge/stacks.ts
@@ -74,6 +74,30 @@ export default class Stacks {
   }
 
   /**
+   * Push content to the top inside a given stack.
+   * Content can be pre-seeded without creating a stack
+   */
+  pushToTop(name: string, contents: string) {
+    let placeholder = this.#placeholders.get(name)
+
+    if (!placeholder) {
+      if (!this.#seededPlaceholders.has(name)) {
+        this.#seededPlaceholders.set(name, [])
+      }
+      const seededPlaceholder = this.#seededPlaceholders.get(name)!
+      seededPlaceholder.unshift(contents)
+      return this
+    }
+
+    /**
+     * Defined content for the unique key inside a given
+     * stack
+     */
+    placeholder.unshift(contents)
+    return this
+  }
+
+  /**
    * Push contents to a stack with a unique source id. A
    * source can only push once to a given stack.
    */
@@ -84,6 +108,28 @@ export default class Stacks {
     }
 
     this.pushTo(name, contents)
+
+    /**
+     * Track source
+     */
+    if (contentSources) {
+      contentSources.add(sourceId)
+    } else {
+      this.#contentSources.set(name, new Set([sourceId]))
+    }
+  }
+
+  /**
+   * Push contents to the top of a stack with a unique source id.
+   * A source can only push once to a given stack.
+   */
+  pushOnceToTop(name: string, sourceId: string, contents: string) {
+    const contentSources = this.#contentSources.get(name)
+    if (contentSources && contentSources.has(sourceId)) {
+      return
+    }
+
+    this.pushToTop(name, contents)
 
     /**
      * Track source

--- a/tests/stacks.spec.ts
+++ b/tests/stacks.spec.ts
@@ -75,7 +75,7 @@ test.group('Stacks', () => {
     stacks.pushTo('js', 'world')
     stacks.pushToTop('js', 'hello')
 
-    assert.equal(stacks.fillPlaceholders(contents), 'hello\nworld')
+    assert.equal(stacks.fillPlaceholders(contents), `hello${EOL}world`)
   })
 
   test('push contents multiple times to stack', ({ assert }) => {
@@ -85,7 +85,7 @@ test.group('Stacks', () => {
     stacks.pushToTop('js', 'world')
     stacks.pushToTop('js', 'hello')
 
-    assert.equal(stacks.fillPlaceholders(contents), `hello\nworld`)
+    assert.equal(stacks.fillPlaceholders(contents), `hello${EOL}world`)
   })
 
   test('push contents to the top before creating the stack', ({ assert }) => {

--- a/tests/stacks.spec.ts
+++ b/tests/stacks.spec.ts
@@ -58,4 +58,43 @@ test.group('Stacks', () => {
 
     assert.equal(stacks.fillPlaceholders(contents), `hello world${EOL}hi world`)
   })
+
+  test('push contents to the top of a stack', ({ assert }) => {
+    const stacks = new Stacks()
+
+    const contents = stacks.create('js')
+    stacks.pushToTop('js', 'hello world')
+
+    assert.equal(stacks.fillPlaceholders(contents), 'hello world')
+  })
+
+  test('push contents to the top of a stack that was already pushed to', ({ assert }) => {
+    const stacks = new Stacks()
+
+    const contents = stacks.create('js')
+    stacks.pushTo('js', 'world')
+    stacks.pushToTop('js', 'hello')
+
+    assert.equal(stacks.fillPlaceholders(contents), 'hello\nworld')
+  })
+
+  test('push contents multiple times to stack', ({ assert }) => {
+    const stacks = new Stacks()
+
+    const contents = stacks.create('js')
+    stacks.pushToTop('js', 'world')
+    stacks.pushToTop('js', 'hello')
+
+    assert.equal(stacks.fillPlaceholders(contents), `hello\nworld`)
+  })
+
+  test('push contents to the top before creating the stack', ({ assert }) => {
+    const stacks = new Stacks()
+
+    stacks.pushToTop('js', 'hello world')
+    stacks.pushToTop('js', 'hi world')
+    const contents = stacks.create('js')
+
+    assert.equal(stacks.fillPlaceholders(contents), `hi world${EOL}hello world`)
+  })
 })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/edge-js/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#172

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds `pushToTop` and `pushToTopOnce` and adds tests for `pushToTop`, mirroring `pushTo`'s tests. I've run the tests locally and it works.

I've got a situation where I have a list of events in the future and in the past, and I want the ones in the past to be in reverse chronological order but the ones in the future to be in chronological order. Rather than having to do that logic in JS, it'd be super nice to just be able to do that with Edge. `pushToTop` makes it super simple to set the events in the past in reverse chronological order without any JS logic around this in my app.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
